### PR TITLE
Update 50-galliumos-baytrail.cfg

### DIFF
--- a/etc/default/grub.d/50-galliumos-baytrail.cfg
+++ b/etc/default/grub.d/50-galliumos-baytrail.cfg
@@ -1,8 +1,10 @@
 # galliumos-baytrail.cfg
 #
-
+ 
 ## gpiolib.acpi_lookup_can_try_crs=1 required for Bay Trail max98090 audio
-KPARMS="gpiolib.acpi_lookup_can_try_crs=1"
+## Added intel_idle.max_cstate=1 because N2930/40 etc is affected by 'Hard Freeze Bug'
+#More info here: https://bugzilla.kernel.org/show_bug.cgi?id=109051
+KPARMS="gpiolib.acpi_lookup_can_try_crs=1  intel_idle.max_cstate=1  intel_idle.max_cstate=1 "
 
 for kparm in $KPARMS; do
   if [ -z "$(echo $GRUB_CMDLINE_LINUX_DEFAULT | grep $kparm)" ]; then


### PR DESCRIPTION
Added intel_idle.max_cstate=1 because N2930/40 etc is affected by 'Hard Freeze Bug'
Decide if it's worth it ;)